### PR TITLE
Exemple of Tests Failing due to Type Changes in the mapped fields of target class

### DIFF
--- a/java-type-enforcing/src/main/java/com/uxjp/GSClass.java
+++ b/java-type-enforcing/src/main/java/com/uxjp/GSClass.java
@@ -1,10 +1,10 @@
 package com.uxjp;
 
 class GSClass {
-    private int field1;
+    private Float field1;
     private String field2;
 
-    public void setField1(int value) {
+    public void setField1(Float value) {
         field1 = value;
     }
 

--- a/java-type-enforcing/src/main/java/com/uxjp/Serializable.java
+++ b/java-type-enforcing/src/main/java/com/uxjp/Serializable.java
@@ -7,7 +7,7 @@ import java.util.Map;
 class Serializable {
     private static final Map<String, Class<?>> fieldMappings = new HashMap<>();
     static {
-        fieldMappings.put("field1", Float.class);
+        fieldMappings.put("field1", int.class);
         fieldMappings.put("field2", String.class);
     }
 

--- a/java-type-enforcing/src/main/java/com/uxjp/Serializable.java
+++ b/java-type-enforcing/src/main/java/com/uxjp/Serializable.java
@@ -7,7 +7,7 @@ import java.util.Map;
 class Serializable {
     private static final Map<String, Class<?>> fieldMappings = new HashMap<>();
     static {
-        fieldMappings.put("field1", int.class);
+        fieldMappings.put("field1", Float.class);
         fieldMappings.put("field2", String.class);
     }
 

--- a/java-type-enforcing/src/test/java/com/uxjp/AppTest.java
+++ b/java-type-enforcing/src/test/java/com/uxjp/AppTest.java
@@ -14,7 +14,7 @@ public class AppTest {
     @Test
     public void testValidateMappingWithValidFields() {
         GSClass gsInstance = new GSClass();
-        gsInstance.setField1(42);
+        gsInstance.setField1(new Float(23.54));
         gsInstance.setField2("Hello");
 
         assertDoesNotThrow(() -> Serializable.validateMapping(gsInstance));


### PR DESCRIPTION
The class `GSClass` is a target to teh mapping existing in class Serializable, changes in the typing of can be caught be  
a methods that validates the original mapping.  

Automated tests paired with this method can assure that type change won't pass unnoticed.


![image](https://github.com/uxjp/java-enforce-type-mapping/assets/38257122/6dd7d721-1135-4b37-a323-2fef8a72ae30)
